### PR TITLE
Update setup.cfg, exclude tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,8 @@ license = BSD0
 packages = find:
 python_requires = >=3.10
 include_package_data = True
+
+[options.packages.find]
+exclude =
+    tests
+    tests.*


### PR DESCRIPTION
otherwise:

 * The following unexpected files/directories were found top-level
 * in the site-packages directory: *
 *   /usr/lib/python3.11/site-packages/tests
 *
 * This is most likely a bug in the build system.  More information
 * can be found in the Python Guide:
 * https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages
 * ERROR: dev-python/aioruckus-0.34::HomeAssistantRepository failed (install phase):
 *   Failing install because of stray top-level files in site-packages